### PR TITLE
proposal for #61

### DIFF
--- a/org.jerkar.core/src/main/java/org/jerkar/tool/builtins/eclipse/DotClasspathGenerator.java
+++ b/org.jerkar.core/src/main/java/org/jerkar/tool/builtins/eclipse/DotClasspathGenerator.java
@@ -78,6 +78,9 @@ final class DotClasspathGenerator {
     /** Can be empty but not null */
     public Iterable<File> projectDependencies = JkUtilsIterable.listOf();
 
+    /** Map from class dir to project dir */
+    public Map<File,File> projectDirsByClassDirs;
+
     /**
      * Constructs a {@link JkDotClasspathGenerator} from the project base
      * directory
@@ -285,7 +288,12 @@ final class DotClasspathGenerator {
                 writeModuleEntry(moduleDependency.moduleId(), writer, resolveResult, attachedArtifacts, paths);
             } else if (dependency instanceof JkFileSystemDependency) {
                 final JkFileSystemDependency fileSystemDependency = (JkFileSystemDependency) dependency;
-                writeFileEntries(fileSystemDependency.files(), writer, paths);
+                final File projectDir = getProjectDir(fileSystemDependency.files());
+                if (projectDir != null) {
+                    writeProjectEntry(projectDir, writer, paths);
+                } else {
+                    writeFileEntries(fileSystemDependency.files(), writer, paths);
+                }
             } else if(dependency instanceof JkComputedDependency) {
                 final JkComputedDependency computedDependency = (JkComputedDependency) dependency;
                 for (final File projectRoot : this.projectDependencies) {
@@ -296,6 +304,16 @@ final class DotClasspathGenerator {
             }
         }
         writeExternalModuleEntries(attachedArtifacts, writer, resolveResult, paths);
+    }
+
+    private File getProjectDir(Set<File> files) {
+        for (final File file : files) {
+            final File projectDir = projectDirsByClassDirs.get(file);
+            if (projectDir != null) {
+                return projectDir;
+            }
+        }
+        return null;
     }
 
     private void writeExternalModuleEntries(JkAttachedArtifacts attachedArtifacts, final XMLStreamWriter writer,

--- a/org.jerkar.core/src/main/java/org/jerkar/tool/builtins/eclipse/DotClasspathGenerator.java
+++ b/org.jerkar.core/src/main/java/org/jerkar/tool/builtins/eclipse/DotClasspathGenerator.java
@@ -309,12 +309,24 @@ final class DotClasspathGenerator {
     }
 
     private File getProjectDir(Set<File> files) {
+
+        // check the files for explicit project settings
         for (final File file : files) {
-            final File projectDir = projectDirsByClassDirs.get(file);
+            if (projectDirsByClassDirs.containsKey(file)) {
+
+                // project dir explicitly set, always use that, even if null
+                return projectDirsByClassDirs.get(file);
+            }
+        }
+
+        // project dir not specified, try to guess
+        for (final File file : files) {
+            final File projectDir = getProjectFolderOf(file);
             if (projectDir != null) {
                 return projectDir;
             }
         }
+
         return null;
     }
 

--- a/org.jerkar.core/src/main/java/org/jerkar/tool/builtins/eclipse/JkBuildPluginEclipse.java
+++ b/org.jerkar.core/src/main/java/org/jerkar/tool/builtins/eclipse/JkBuildPluginEclipse.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.jerkar.api.depmanagement.JkDependencies;
-import org.jerkar.api.depmanagement.JkFileSystemDependency;
 import org.jerkar.api.file.JkFileTreeSet;
 import org.jerkar.api.system.JkLog;
 import org.jerkar.tool.JkBuild;
@@ -161,22 +160,11 @@ public final class JkBuildPluginEclipse extends JkJavaBuildPlugin {
     }
 
     /**
-     * Create a classpath dependency on a project's class folder, but make the .classpath reference the whole project.
-     * @param projectDir path to the project directory
-     * @param classesSubdir path (relative to projectDir) of the classes dir
-     */
-    public JkFileSystemDependency projectClasses(String projectDir, String classesSubdir) {
-        final File dir = new File(projectDir);
-        return projectClasses(dir, new File(dir, classesSubdir));
-    }
-
-    /**
-     * Create a classpath dependency on a project's class folder, but make the .classpath reference the whole project.
-     * @param projectDir directory of the project
+     * When a file dependency is found at classesDir, make a project reference instead of a class folder reference in the .classpath file.
      * @param classesDir directory of the classes
+     * @param projectDir directory of the project
      */
-    public JkFileSystemDependency projectClasses(File projectDir, File classesDir) {
+    public void addProjectFromClasses(File classesDir, File projectDir) {
         projectDirsByClassDirs.put(classesDir, projectDir);
-        return JkFileSystemDependency.of(classesDir);
     }
 }


### PR DESCRIPTION
Here's a proposal for the reference-classes-dirs-as-projects-on-the-eclipse-.classpath enhancement.

And here's a quick usage example:
```java
private JkBuildPluginEclipse eclipse;

@Override
public void init() {
	super.init();
	eclipse = new JkBuildPluginEclipse();
	eclipse.setStandardJREContainer("openjdk-8u121-noFX");
	plugins.configure(eclipse);
}

@Override
public JkDependencies dependencies() {
	return JkDependencies.builder()
		.on(eclipse.projectClasses("/path/to/project", "bin"))
		.build();
}
```
`JkBuildPluginEclipse.projectClasses` returns a regular `JkFileSystemDependency` for the dependency, but it tracks the project dir internally for a later call to `JkBuildPluginEclipse.generateFiles()`.

Let me know if you like it, or if you want any changes.