### PR TITLE
apply useAbsolutePaths flag to source attachments too

### DIFF
--- a/org.jerkar.core/src/main/java/org/jerkar/tool/builtins/eclipse/DotClasspathGenerator.java
+++ b/org.jerkar.core/src/main/java/org/jerkar/tool/builtins/eclipse/DotClasspathGenerator.java
@@ -391,8 +391,11 @@ final class DotClasspathGenerator {
 
         writer.writeAttribute("path", binPath);
         if (source != null && source.exists()) {
-            final VarReplacement sourceReplacement = new VarReplacement(source);
-            writer.writeAttribute("sourcepath", sourceReplacement.path);
+            String srcPath = source.getAbsolutePath();
+            if (!useAbsolutePaths) {
+                srcPath = new VarReplacement(source).path;
+            }
+            writer.writeAttribute("sourcepath", srcPath);
         }
         if (javadoc != null && javadoc.exists()) {
             writer.writeCharacters("\n\t\t");


### PR DESCRIPTION
I missed fixing paths for source attachments when I made the `useAbsolutePaths` flag in the Eclipse plugin. Here's the fix. =)